### PR TITLE
[BB-3175] Fix DRF compatibility

### DIFF
--- a/rest_auth/views.py
+++ b/rest_auth/views.py
@@ -90,8 +90,7 @@ class LoginView(GenericAPIView):
 
     def post(self, request, *args, **kwargs):
         self.request = request
-        self.serializer = self.get_serializer(data=self.request.data,
-                                              context={'request': request})
+        self.serializer = self.get_serializer(data=self.request.data)
         self.serializer.is_valid(raise_exception=True)
 
         self.login()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ f.close()
 
 setup(
     name='django-rest-auth',
-    version='0.9.5',
+    version='0.10.1',
     author='Sumit Chachra',
     author_email='chachra@tivix.com',
     url='http://github.com/Tivix/django-rest-auth',


### PR DESCRIPTION
The behavior of `get_serializer` has been changed in  DRF 3.12.0 - it does not override `kwargs['context']` anymore, which results in the lack of `view` in the `context`.

https://github.com/encode/django-rest-framework/commit/e275b9036a274ad06d9ffa58b4c17293e0fe0564